### PR TITLE
chore: 🎉 Add this repo as a component to the a developer-portal

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+# yamllint disable-file
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "bower-ui-grid"
+  description: "This repo is for distribution on npm and bower. The source for this module is in the main UI Grid repo. Please file issues and pull requests against that repo."
+  title: "Bower UI Grid"
+  tags:
+    - emr
+spec:
+  type: "library"
+  owner: "group:default/emr-tasy-framework-contributors"
+  lifecycle: "production"


### PR DESCRIPTION
This pull request adds a `catalog-info.yaml` file to the root of this repository.
This triggers it to be indexed and added to the [software catalog](https://portal.internal.philips/catalog) in the [developer-portal](https://portal.internal.philips/)

For details, [please take a look at our documentation](https://portal.internal.philips/docs/default/component/developer-portal). And read about [Adding to the catalog](https://portal.internal.philips/docs/default/component/developer-portal/catalog/adding-a-component/)

---
> _This PR is automated by the [Developer Portal](https://portal.internal.philips/)_
